### PR TITLE
Add git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
This adds a minimal git ignore file that ignores the Cargo lockfile as-well as the default build target directory.