### PR TITLE
Fix wrong link name for alc_capture_open_device

### DIFF
--- a/src/alc.rs
+++ b/src/alc.rs
@@ -110,7 +110,7 @@ extern "C" {
         values: *mut alc_int,
     );
 
-    #[link_name="alcCreateContext"]
+    #[link_name="alcCaptureOpenDevice"]
     pub fn alc_capture_open_device(
         devicename: *const alc_char,
         frequency: alc_uint,


### PR DESCRIPTION
The `alc_capture_open_device` extern has been given the link name alcCreateContext.

This corrects that by changing it to `alcCaptureOpenDevice`.