### PR TITLE
Fix wrong link name for alc_capture_stop

### DIFF
--- a/src/alc.rs
+++ b/src/alc.rs
@@ -124,7 +124,7 @@ extern "C" {
     #[link_name="alcCaptureStart"]
     pub fn alc_capture_start(device: *mut alc_device);
 
-    #[link_name="alcCreateContext"]
+    #[link_name="alcCaptureStop"]
     pub fn alc_capture_stop(device: *mut alc_device);
 
     #[link_name="alcCaptureSamples"]


### PR DESCRIPTION
The alc_stop_capture extern has been given the link name alcCreateContext.

This corrects that by changing it to alcStopCapture.