### PR TITLE
Deny warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 mod al;
 mod alc;
 


### PR DESCRIPTION
This disallows all warnings, as it catches useful things like link name re-declarations.