### PR TITLE
Limit the number of test threads to one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TEST_THREADS: 1
 
 jobs:
   test:


### PR DESCRIPTION
This limits the number of threads the rust test runner can use to one to deal with some of the test flakyness.